### PR TITLE
deps: update renovate config

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -4,40 +4,32 @@
     {
       "groupName": "all actions",
       "groupSlug": "all-actions",
-      "matchManagers": [
-        "github-actions"
-      ],
-      "extends": [
-        "schedule:weekly"
-      ]
+      "matchManagers": ["github-actions"],
+      "extends": ["schedule:weekly"]
     },
     {
       "groupName": "submodules",
       "groupSlug": "submodule",
-      "matchManagers": [
-        "git-submodules"
-      ],
-      "extends": [
-        "schedule:weekly"
-      ]
+      "matchManagers": ["git-submodules"],
+      "extends": ["schedule:weekly"]
     },
     {
       "matchManagers": ["dockerfile"],
       "groupName": "docker dependencies",
       "groupSlug": "docker",
-      "extends": [
-        "schedule:weekly"
-      ]
+      "extends": ["schedule:weekly"]
+    },
+    {
+      "groupName": "cargo",
+      "groupSlug": "cargo",
+      "matchManagers": ["cargo"],
+      "extends": ["schedule:weekly"]
     }
   ],
   "patch": {
-    "enabled": false
-  },
-  "major": {
-    "enabled": false
-  },
-  "minor": {
-    "enabled": false
+    "cargo": {
+      "enabled": false
+    }
   },
   "cloneSubmodules": true,
   "separateMajorMinor": false,

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -8,12 +8,6 @@
       "extends": ["schedule:weekly"]
     },
     {
-      "groupName": "submodules",
-      "groupSlug": "submodule",
-      "matchManagers": ["git-submodules"],
-      "extends": ["schedule:weekly"]
-    },
-    {
       "matchManagers": ["dockerfile"],
       "groupName": "docker dependencies",
       "groupSlug": "docker",
@@ -34,6 +28,6 @@
   "cloneSubmodules": true,
   "separateMajorMinor": false,
   "git-submodules": {
-    "enabled": true
+    "enabled": false
   }
 }


### PR DESCRIPTION
Updates the renovate config:

- Enables patch dependencies (except for cargo)
- Enables minor dependencies
- Enables major dependencies
- Disables submodules, as it doesn't work for us as expected - it should update the lockfile, but it doesn't (e.g. https://github.com/twitch-rs/twitch_api/pull/420)
- (formatted with prettier because I have _format on save_ on)

See also: https://github.com/twitch-rs/twitch_api/pull/416