### PR TITLE
fix: restrict managers and exclude own dependencies

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     {
-      "groupName": "all actions",
+      "groupName": "actions",
       "groupSlug": "all-actions",
       "matchManagers": ["github-actions"],
       "extends": ["schedule:weekly"]
@@ -14,16 +14,15 @@
       "extends": ["schedule:weekly"]
     },
     {
-      "groupName": "cargo",
+      "groupName": "rust dependencies",
       "groupSlug": "cargo",
       "matchManagers": ["cargo"],
-      "extends": ["schedule:weekly"]
+      "extends": ["schedule:weekly"],
+      "excludePackageNames": ["twitch_oauth2", "twitch_types"]
     }
   ],
   "patch": {
-    "cargo": {
-      "enabled": false
-    }
+    "enabledManagers": ["github-actions", "dockerfile"]
   },
   "cloneSubmodules": true,
   "separateMajorMinor": false,


### PR DESCRIPTION
- Restricts managers for `patch` level (not sure if this works)
- Renames the groups so the pr title is meaningful ("chore(deps): update <group-name>")
- Removes `twitch_oauth2` and `twitch_types` from cargo dependencies