### PR TITLE
deps: disable patch and docker dependencies

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -8,12 +8,6 @@
       "extends": ["schedule:weekly"]
     },
     {
-      "matchManagers": ["dockerfile"],
-      "groupName": "docker dependencies",
-      "groupSlug": "docker",
-      "extends": ["schedule:weekly"]
-    },
-    {
       "groupName": "rust dependencies",
       "groupSlug": "cargo",
       "matchManagers": ["cargo"],
@@ -22,11 +16,14 @@
     }
   ],
   "patch": {
-    "enabledManagers": ["github-actions", "dockerfile"]
+    "enabled": false
   },
   "cloneSubmodules": true,
   "separateMajorMinor": false,
   "git-submodules": {
+    "enabled": false
+  },
+  "dockerfile": {
     "enabled": false
   }
 }


### PR DESCRIPTION
I don't know how to restrict patch updates (https://github.com/twitch-rs/twitch_types/pull/59, https://github.com/twitch-rs/twitch_api/pull/422) other than disabling them.
Since the docker updates don't work for us (https://github.com/twitch-rs/twitch_api/pull/423), I've disabled them too.

This will still cause a PR if we update one of our crates to a new major/minor version, but I'd guess we're faster.